### PR TITLE
feat: add optional json logging format for advanced configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ For a complete list of variables check the section below.
 | `PYROSCOPE_TENANT_ID`           | `""`                             | phlare tenant ID, passed as X-Scope-OrgID http header                                      |
 | `PYROSCOPE_BASIC_AUTH_USER`     | `""` | HTTP basic auth user |
 | `PYROSCOPE_BASIC_AUTH_PASSWORD` | `""`  | HTTP basic auth password  |
+| `PYROSCOPE_LOG_FORMAT`                  | `"text"`         | format to choose from from `"text"` and `"json"`                                        |
+| `PYROSCOPE_LOG_TIMESTAMP_FORMAT`        | `time.RFC3339`   | logging timestamp format ([go time format](https://golang.org/pkg/time/#pkg-constants)) |
+| `PYROSCOPE_LOG_TIMESTAMP_DISABLE`       | `false`          | disables automatic timestamps in logging output                                         |
+| `PYROSCOPE_LOG_TIMESTAMP_FIELD_NAME`    | `"time"`         | change default field name in logs of automatic timestamps                               |
+| `PYROSCOPE_LOG_LEVEL_FIELD_NAME`        | `"level"`        | change default field name in logs of level                                              |
+| `PYROSCOPE_LOG_MSG_FIELD_NAME`          | `"msg"`          | change default field name in logs of message                                            |
+| `PYROSCOPE_LOG_LOGRUS_ERROR_FIELD_NAME` | `"logrus_error"` | change default field name in logs of logrus error                                       |
+| `PYROSCOPE_LOG_FUNC_FIELD_NAME`         | `"func"`         | change default field name in logs of caller function                                    |
+| `PYROSCOPE_LOG_FILE_FIELD_NAME`         | `"file"`         | change default field name in logs of caller file                                        |
 
 # How it works
 The profiler will run as normal, and periodically will send data to the relay server (the server running at `http://localhost:4040`).

--- a/main.go
+++ b/main.go
@@ -28,6 +28,22 @@ var (
 	// 'trace' | 'debug' | 'info' | 'error'
 	logLevel = getEnvStrOr("PYROSCOPE_LOG_LEVEL", "info")
 
+	// log format options 'json' | 'text'
+	logFormat = getEnvStrOr("PYROSCOPE_LOG_FORMAT", "text")
+
+	// log timestamp format (default: time.RFC3339), see https://golang.org/pkg/time/#pkg-constants
+	logTsFormat = getEnvStrOr("PYROSCOPE_LOG_TIMESTAMP_FORMAT", time.RFC3339)
+
+	logDisableTs = getEnvBool("PYROSCOPE_LOG_TIMESTAMP_DISABLE")
+
+	// log field names
+	logTsFieldName    = getEnvStrOr("PYROSCOPE_LOG_TIMESTAMP_FIELD_NAME", logrus.FieldKeyTime)
+	logLevelFieldName = getEnvStrOr("PYROSCOPE_LOG_LEVEL_FIELD_NAME", logrus.FieldKeyLevel)
+	logMsgFieldName   = getEnvStrOr("PYROSCOPE_LOG_MSG_FIELD_NAME", logrus.FieldKeyMsg)
+	logErrorFieldName = getEnvStrOr("PYROSCOPE_LOG_LOGRUS_ERROR_FIELD_NAME", logrus.FieldKeyLogrusError)
+	logFuncFieldName  = getEnvStrOr("PYROSCOPE_LOG_FUNC_FIELD_NAME", logrus.FieldKeyFunc)
+	logFileFieldName  = getEnvStrOr("PYROSCOPE_LOG_FILE_FIELD_NAME", logrus.FieldKeyFile)
+
 	// to where relay data to
 	remoteAddress = getEnvStrOr("PYROSCOPE_REMOTE_ADDRESS", "https://ingest.pyroscope.cloud")
 
@@ -106,6 +122,38 @@ func initLogger() *logrus.Entry {
 	}
 
 	logrus.SetLevel(lvl)
+
+	var f logrus.Formatter
+	switch logFormat {
+	case "json":
+		f = &logrus.JSONFormatter{
+			TimestampFormat:  logTsFormat,
+			DisableTimestamp: logDisableTs,
+			FieldMap: logrus.FieldMap{
+				logrus.FieldKeyTime:        logTsFieldName,
+				logrus.FieldKeyLevel:       logLevelFieldName,
+				logrus.FieldKeyMsg:         logMsgFieldName,
+				logrus.FieldKeyLogrusError: logErrorFieldName,
+				logrus.FieldKeyFunc:        logFuncFieldName,
+				logrus.FieldKeyFile:        logFileFieldName,
+			},
+		}
+	default:
+		f = &logrus.TextFormatter{
+			TimestampFormat:  logTsFormat,
+			DisableTimestamp: logDisableTs,
+			FieldMap: logrus.FieldMap{
+				logrus.FieldKeyTime:        logTsFieldName,
+				logrus.FieldKeyLevel:       logLevelFieldName,
+				logrus.FieldKeyMsg:         logMsgFieldName,
+				logrus.FieldKeyLogrusError: logErrorFieldName,
+				logrus.FieldKeyFunc:        logFuncFieldName,
+				logrus.FieldKeyFile:        logFileFieldName,
+			},
+		}
+	}
+	logrus.SetFormatter(f)
+
 	return logger
 }
 


### PR DESCRIPTION
Add extra environment variables to further configure the logrus logger in the extension.

This is very useful when the target app has to deal with different logger setups such as zerolog, zap, go-logr and others. This happens when integrating different lambda extensions and other libraries such as OpenTelemetry and the target application has zap or zerolog.

There are not significant code changes and not setting a variable will result in using the defaults previously used in the extension (logrus defaults) ensure compatibility with exiting users.

This feature enables the following setups:
- Use json as a formatter
- Skip sending timestamps as part of the log entry
- Specify the format of the timestamps
- Change default field names of logrus allowing log entries to use "ts" instead of "time" for example.

To use it, just setup the corresponding environment variables in the AWS lambda configuration and you can have logs like this ones:

```
{"level":"debug","msg":"Serving on 0.0.0.0:4040","svc":"pyroscope-lambda-ext-main","ts":"2023-07-18T12:47:58.318877953Z"}
{"comp":"orchestrator","level":"debug","msg":"Starting Server","svc":"pyroscope-lambda-ext-main","ts":"2023-07-18T12:47:58.31884208Z"}
{"comp":"orchestrator","level":"debug","msg":"Starting Server","svc":"pyroscope-lambda-ext-main","ts":"2023-07-18T12:47:58.31884208Z"}
{"comp":"orchestrator","level":"debug","msg":"Starting self profiler","svc":"pyroscope-lambda-ext-main","ts":"2023-07-18T12:47:58.318807397Z"}
```