### PR TITLE
fix: use format string in Fatalf to fix go vet error

### DIFF
--- a/relay/remotequeue_flush_test.go
+++ b/relay/remotequeue_flush_test.go
@@ -28,7 +28,7 @@ func newAsyncJob(t *testing.T, name string, f func()) *asyncJob {
 func (j *asyncJob) assertNotFinished() {
 	locked := j.m.TryLock()
 	if locked {
-		j.t.Fatalf("should be still working... " + j.name)
+		j.t.Fatalf("should be still working... %s", j.name)
 	}
 }
 


### PR DESCRIPTION
## Problem

`go vet` (run as part of `go test`) now rejects non-constant format strings passed to `Fatalf`. This caused the CI workflow to fail on both `amd64` and `arm64` matrix jobs:

```
relay/remotequeue_flush_test.go:31:14: non-constant format string in call to (*testing.common).Fatalf
FAIL	github.com/pyroscope-io/pyroscope-lambda-extension/relay [build failed]
```

## Fix

Replace string concatenation with a proper format string:

```go
// before
j.t.Fatalf("should be still working... " + j.name)

// after
j.t.Fatalf("should be still working... %s", j.name)
```