### PR TITLE
ci: use GitHub App token for release-please instead of PAT secret

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,7 +10,20 @@ name: release-please
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    outputs:
+      release_created: ${{ steps.rp.outputs.release_created }}
+      tag_name: ${{ steps.rp.outputs.tag_name }}
+      sha: ${{ steps.rp.outputs.sha }}
     steps:
-      - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.2.0
+      - id: get-github-app-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          github_app: pyroscope-development-app
+      - id: rp
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
+        with:
+          token: ${{ steps.get-github-app-token.outputs.token }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Problem

The `release-please` workflow has been failing on every push to `main` with:

```
##[error]release-please failed: Input required and not supplied: token
```

The workflow used `secrets.RELEASE_PLEASE_TOKEN` which is not configured in this repo.

## Fix

Mirrors the approach used in [grafana/otel-profiling-java#105](https://github.com/grafana/otel-profiling-java/pull/105):

- Use `grafana/shared-workflows/actions/create-github-app-token` to obtain a token from the `pyroscope-development-app` GitHub App instead of a PAT secret
- Upgrade `googleapis/release-please-action` from pinned v4.2.0 SHA to v5 (pinned SHA)
- Add `id-token: write` permission required by the GitHub App token action
- Wire up the existing `release-please-config.json` and `.release-please-manifest.json` files explicitly